### PR TITLE
feat: Support Kakao OAuth login without email requirement

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -100,7 +100,7 @@ src/
 | Styling | Tailwind CSS 4 | Utility‑first CSS framework with Korean font support |
 | Database | PostgreSQL | Primary data store (Railway for production) |
 | ORM | Prisma 6.8+ | Type‑safe database client with auto-generation |
-| Authentication | NextAuth.js 4.24+ | OAuth authentication (Google, Kakao) |
+| Authentication | NextAuth.js 4.24+ | OAuth authentication (Google, Kakao) - See [Kakao OAuth Setup](KAKAO_OAUTH_SETUP.md) |
 | State Management | React Hooks + SWR | Client state and server state management |
 | UI Components | shadcn/ui | Accessible component library |
 | Timeline Backend | Custom Service | Native timeline with real-time updates via SSE |
@@ -116,7 +116,7 @@ src/
 ### 5.1 Authentication Flow
 | Flow | Implementation | Status |
 |------|----------------|--------|
-| OAuth Login | Google/Kakao OAuth → NextAuth.js → automatic username generation | ✅ Implemented |
+| OAuth Login | Google/Kakao OAuth → NextAuth.js → automatic username generation (email optional for Kakao) | ✅ Implemented |
 | User Registration | OAuth signup → profile creation → dashboard redirect | ✅ Implemented |
 | Session Management | JWT sessions with middleware protection | ✅ Implemented |
 

--- a/KAKAO_OAUTH_SETUP.md
+++ b/KAKAO_OAUTH_SETUP.md
@@ -1,0 +1,119 @@
+# Kakao OAuth Setup Guide
+
+This guide explains how to set up Kakao OAuth for the Kemotown application.
+
+## Prerequisites
+
+1. A Kakao account
+2. Access to the Kakao Developers console
+
+## Setup Steps
+
+### 1. Create a Kakao Application
+
+1. Go to [Kakao Developers](https://developers.kakao.com/)
+2. Sign in with your Kakao account
+3. Navigate to "My Application" (내 애플리케이션)
+4. Click "Add Application" (애플리케이션 추가하기)
+5. Fill in the application details:
+   - App Name: Kemotown
+   - Company Name: (Your company/organization name)
+   - Category: Social
+
+### 2. Configure OAuth Settings
+
+1. In your application dashboard, go to "App Keys" (앱 키) to find your credentials:
+   - REST API Key (This is your `KAKAO_CLIENT_ID`)
+   - Client Secret (This is your `KAKAO_CLIENT_SECRET`)
+
+2. Go to "Platform" (플랫폼) settings:
+   - Click "Web Platform Registration" (Web 플랫폼 등록)
+   - Add your site domains:
+     - For development: `http://localhost:3000`
+     - For production: Your production domain (e.g., `https://kemotown.com`)
+
+3. Configure "Kakao Login" (카카오 로그인):
+   - Navigate to "Kakao Login" in the left menu
+   - Toggle "Kakao Login" to ON (활성화 설정: ON)
+   - Set Redirect URI:
+     - For development: `http://localhost:3000/api/auth/callback/kakao`
+     - For production: `https://yourdomain.com/api/auth/callback/kakao`
+
+4. Configure consent items (동의항목):
+   - Go to "Consent Items" (동의항목)
+   - Enable the following permissions:
+     - Profile Info (프로필 정보): Required
+     - Email (카카오계정(이메일)): Optional (Business account required for "Required")
+   
+   **Note for Non-Business Accounts**: If you don't have a Kakao business account, you cannot make email a required field. The application has been updated to support Kakao users without email addresses. Users will be identified by their Kakao ID instead.
+
+### 3. Update Environment Variables
+
+Update your `.env.local` file with the credentials from Kakao:
+
+```env
+# Kakao OAuth
+KAKAO_CLIENT_ID="your-rest-api-key"
+KAKAO_CLIENT_SECRET="your-client-secret"
+```
+
+### 4. Important Security Notes
+
+1. **Client Secret Generation**: 
+   - In the Kakao Developers console, go to "Security" (보안)
+   - Click "Generate Client Secret" (Client Secret 생성)
+   - Toggle "Client Secret Code" to ON (활성화)
+   - Copy the generated secret immediately (it won't be shown again)
+
+2. **Production Considerations**:
+   - Always use HTTPS in production
+   - Keep your Client Secret secure and never commit it to version control
+   - Regularly rotate your Client Secret
+
+3. **Redirect URI Configuration**:
+   - The redirect URI must match exactly with what's configured in NextAuth
+   - Include both development and production URLs in your Kakao app settings
+
+### 5. Testing
+
+1. Ensure your environment variables are set correctly
+2. Start the development server: `npm run dev`
+3. Navigate to the login page
+4. Click "카카오로 로그인" (Login with Kakao)
+5. You should be redirected to Kakao's OAuth consent page
+6. After authorization, you'll be redirected back to your application
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Invalid redirect URI" error**:
+   - Ensure the redirect URI in Kakao Developers matches exactly: `/api/auth/callback/kakao`
+   - Check that your domain is registered in the platform settings
+
+2. **"Client authentication failed" error**:
+   - Verify your KAKAO_CLIENT_ID and KAKAO_CLIENT_SECRET are correct
+   - Ensure Client Secret is activated in the Kakao Developers console
+
+3. **"Access was denied" error after successful Kakao login**:
+   - For older versions: This meant the user didn't share their email address
+   - **Current version**: The app now supports Kakao users without email
+   - If you still see this error, ensure you're using the latest code that makes email optional
+
+4. **Login works locally but not in production**:
+   - Add your production domain to the platform settings
+   - Update redirect URIs to include your production URL
+   - Ensure NEXTAUTH_URL is set correctly in production
+
+### Debug Mode
+
+To enable debug logging for NextAuth:
+
+1. Set `debug: true` in your NextAuth configuration (already configured to false in production)
+2. Check the console logs for detailed error messages
+
+## Additional Resources
+
+- [Kakao Login Documentation](https://developers.kakao.com/docs/latest/ko/kakaologin/common)
+- [NextAuth.js Kakao Provider](https://next-auth.js.org/providers/kakao)
+- [NextAuth.js Debugging](https://next-auth.js.org/configuration/options#debug)

--- a/README.md
+++ b/README.md
@@ -43,12 +43,18 @@ Kemotown is a dedicated platform designed to provide a semi-formal digital space
    npm install
    ```
 
-3. Run the development server:
+3. Set up environment variables:
+   - Copy `.env.example` to `.env.local`
+   - Configure OAuth providers:
+     - For Google OAuth: Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+     - For Kakao OAuth: Follow the [Kakao OAuth Setup Guide](KAKAO_OAUTH_SETUP.md)
+
+4. Run the development server:
    ```bash
    npm run dev
    ```
 
-4. Open [http://localhost:3000](http://localhost:3000) in your browser.
+5. Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ### Available Scripts
 

--- a/prisma/migrations/20250524180000_make_email_optional_for_kakao/migration.sql
+++ b/prisma/migrations/20250524180000_make_email_optional_for_kakao/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "email" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model Session {
 model User {
   id                String    @id @default(cuid())
   name              String?
-  email             String    @unique
+  email             String?   @unique
   emailVerified     DateTime?
   image             String?
   

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -58,10 +58,12 @@ export const authOptions: NextAuthOptions = {
     async signIn({ user, account }) {
       // Only allow OAuth sign-ins from Google and Kakao
       if (account?.provider === 'google' || account?.provider === 'kakao') {
-        // Verify user has an email
-        if (!user?.email) {
+        // Google requires email
+        if (account.provider === 'google' && !user?.email) {
           return false;
         }
+        // Kakao users might not have email (non-business accounts)
+        // They can still sign in using their Kakao ID
         return true;
       }
       


### PR DESCRIPTION
- Make email field optional in User schema to support Kakao non-business accounts
- Update auth logic to allow Kakao users without email while keeping email required for Google
- Add comprehensive Kakao OAuth setup documentation
- Create migration to make email column nullable
- Update README and DESIGN docs with Kakao OAuth references

This change enables developers without Kakao business accounts to use OAuth, as they cannot make email a required consent item.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive documentation and setup guide for integrating Kakao OAuth, including step-by-step instructions and troubleshooting tips.

- **Documentation**
  - Updated authentication documentation to clarify the handling of optional emails for Kakao OAuth users.
  - Improved README installation steps to include environment variable setup for OAuth providers.

- **Bug Fixes**
  - Adjusted sign-in logic to allow Kakao users to authenticate without an email address.

- **Refactor**
  - Modified the user model and database to make the email field optional, supporting users without email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->