### PR TITLE
fix: Show context posts on public timeline when context is public

### DIFF
--- a/src/components/timeline/ActivityComposer.tsx
+++ b/src/components/timeline/ActivityComposer.tsx
@@ -82,11 +82,11 @@ export function ActivityComposer({
     onSuccess: () => {
       setContent('');
       // Invalidate relevant timelines
+      // Always invalidate public/home since context posts in PUBLIC contexts also appear there
+      utils.activity.publicTimeline.invalidate();
+      utils.activity.homeTimeline.invalidate();
       if (contextId) {
         utils.activity.contextTimeline.invalidate({ contextId });
-      } else {
-        utils.activity.publicTimeline.invalidate();
-        utils.activity.homeTimeline.invalidate();
       }
       onSuccess?.();
     },


### PR DESCRIPTION
## Summary
- Posts in **public** contexts (events, groups) now automatically appear on the global public timeline
- Previously, posts with visibility "context" (members only) were invisible on the public timeline even when the context itself was public
- Server-side fix: `createNoteActivity` checks context visibility and adds `'public'` to addressing when appropriate

## Technical Details
The fix uses ActivityPub-style addressing semantics:
- When posting to a `PUBLIC` context, `'public'` is added to the `to` array
- When posting to a `PRIVATE` or `UNLISTED` context, posts remain context-only
- This ensures the public timeline query (`to: { has: 'public' }`) correctly includes these posts

## Test plan
- [ ] Create a post in a public event/group with visibility "멤버만" (context only)
- [ ] Verify post appears on the global home timeline
- [ ] Create a post in a private event/group
- [ ] Verify post does NOT appear on the global home timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where posts created in public contexts were not appearing on the global timeline, ensuring better content discoverability.
* Improved timeline refresh behavior to ensure posts are consistently updated across all timeline views upon creation, providing more reliable content synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->