### PR TITLE
fix: Add runtime auth debug endpoint

### DIFF
--- a/src/app/api/auth/debug/route.ts
+++ b/src/app/api/auth/debug/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Auth Debug Endpoint
+ * Returns the current auth configuration status at runtime
+ * DELETE THIS FILE after debugging is complete
+ */
+
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // Check environment variables at runtime
+  const config = {
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV,
+
+    // Auth secret
+    hasAuthSecret: !!process.env.AUTH_SECRET,
+    hasNextAuthSecret: !!process.env.NEXTAUTH_SECRET,
+    secretSource: process.env.AUTH_SECRET ? 'AUTH_SECRET' :
+                  process.env.NEXTAUTH_SECRET ? 'NEXTAUTH_SECRET' : 'NONE',
+
+    // OAuth credentials (lengths only, not values)
+    google: {
+      hasClientId: !!process.env.GOOGLE_CLIENT_ID,
+      hasClientSecret: !!process.env.GOOGLE_CLIENT_SECRET,
+      clientIdLength: process.env.GOOGLE_CLIENT_ID?.length || 0,
+      clientSecretLength: process.env.GOOGLE_CLIENT_SECRET?.length || 0,
+    },
+    kakao: {
+      hasClientId: !!process.env.KAKAO_CLIENT_ID,
+      hasClientSecret: !!process.env.KAKAO_CLIENT_SECRET,
+      clientIdLength: process.env.KAKAO_CLIENT_ID?.length || 0,
+      clientSecretLength: process.env.KAKAO_CLIENT_SECRET?.length || 0,
+    },
+
+    // URL configuration
+    urls: {
+      nextauthUrl: process.env.NEXTAUTH_URL || null,
+      authUrl: process.env.AUTH_URL || null,
+      vercelUrl: process.env.VERCEL_URL || null,
+    },
+
+    // Database
+    hasDatabaseUrl: !!process.env.DATABASE_URL,
+    databaseUrlPrefix: process.env.DATABASE_URL?.substring(0, 20) + '...' || null,
+  };
+
+  return NextResponse.json(config);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -57,6 +57,9 @@ console.log('[Auth] Configuration status:', {
   hasKakaoCredentials: !!(kakaoClientId && kakaoClientSecret),
   googleClientIdLength: googleClientId?.length || 0,
   nodeEnv: process.env.NODE_ENV,
+  nextauthUrl: process.env.NEXTAUTH_URL || '(not set)',
+  authUrl: process.env.AUTH_URL || '(not set)',
+  vercelUrl: process.env.VERCEL_URL || '(not set)',
 });
 
 // Build providers array dynamically based on available credentials
@@ -172,7 +175,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       }
     },
   },
-  debug: process.env.NODE_ENV === 'development',
+  // Enable debug mode - set AUTH_DEBUG=true in Vercel to see detailed logs
+  debug: process.env.AUTH_DEBUG === 'true' || process.env.NODE_ENV === 'development',
+  logger: {
+    error: (code, ...message) => {
+      console.error('[Auth Error]', code, JSON.stringify(message, null, 2));
+    },
+    warn: (code) => {
+      console.warn('[Auth Warn]', code);
+    },
+    debug: (code, ...message) => {
+      console.log('[Auth Debug]', code, JSON.stringify(message, null, 2));
+    },
+  },
 });
 
 // Export auth config for middleware


### PR DESCRIPTION
## Summary
Adds a debug endpoint to check auth configuration at **runtime** (not just build time).

## How to Use
After deploying, visit: **https://www.kemo.town/api/auth/debug**

You'll see JSON like:
```json
{
  "timestamp": "2024-01-05T...",
  "environment": "production",
  "hasAuthSecret": true,
  "hasNextAuthSecret": true,
  "secretSource": "NEXTAUTH_SECRET",
  "google": {
    "hasClientId": true,
    "hasClientSecret": true,
    "clientIdLength": 72,
    "clientSecretLength": 35
  },
  "urls": {
    "nextauthUrl": "https://www.kemo.town",
    "authUrl": null,
    "vercelUrl": "kemotown-xxx.vercel.app"
  },
  "hasDatabaseUrl": true
}
```

## What to Check
1. All credentials should show `true`
2. `nextauthUrl` should be `https://www.kemo.town`
3. `clientIdLength` should be ~72, `clientSecretLength` should be ~35

## Also Added
- Set `AUTH_DEBUG=true` in Vercel to see detailed Auth.js logs
- Custom logger to capture all auth errors

## ⚠️ Important
**DELETE the `/api/auth/debug` endpoint after debugging is complete!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)